### PR TITLE
[FEAT] error handling base code 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/src/main/java/com/manyaak/manyaakback/global/exception/BusinessLogicException.java
+++ b/src/main/java/com/manyaak/manyaakback/global/exception/BusinessLogicException.java
@@ -1,0 +1,13 @@
+package com.manyaak.manyaakback.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessLogicException extends RuntimeException {
+    private ExceptionCode exceptionCode;
+
+    public BusinessLogicException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/com/manyaak/manyaakback/global/exception/ExceptionCode.java
+++ b/src/main/java/com/manyaak/manyaakback/global/exception/ExceptionCode.java
@@ -1,0 +1,16 @@
+package com.manyaak.manyaakback.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionCode {
+    MEMBER_NOT_EXISTS(404, "해당 멤버가 존재하지 않습니다");
+
+    private int status;
+    private String message;
+
+    ExceptionCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/manyaak/manyaakback/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/manyaak/manyaakback/global/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,61 @@
+package com.manyaak.manyaakback.global.exception;
+
+
+import com.manyaak.manyaakback.global.response.ErrorResponse;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ErrorResponse.of(e.getBindingResult());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
+        return ErrorResponse.of(e.getConstraintViolations());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleHttpMessageMotReadableException(HttpMessageNotReadableException e) {
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, "Required request body is missing");
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleEntityNotFoundException(EntityNotFoundException e) {
+        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity handleBusinessLogException(BusinessLogicException e) {
+        final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
+
+        return new ResponseEntity(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
+    }
+}

--- a/src/main/java/com/manyaak/manyaakback/global/response/ErrorResponse.java
+++ b/src/main/java/com/manyaak/manyaakback/global/response/ErrorResponse.java
@@ -1,0 +1,89 @@
+package com.manyaak.manyaakback.global.response;
+
+import com.manyaak.manyaakback.global.exception.ExceptionCode;
+import jakarta.validation.ConstraintViolation;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private List<FieldError> fieldErrors;
+    private List<ConstraintViolationError> violationErrors;
+
+    private ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private ErrorResponse(List<FieldError> fieldErrors, List<ConstraintViolationError> violationErrors) {
+        this.fieldErrors = fieldErrors;
+        this.violationErrors = violationErrors;
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(FieldError.of(bindingResult), null);
+    }
+
+    public static ErrorResponse of(Set<ConstraintViolation<?>> violations) {
+        return new ErrorResponse(null, ConstraintViolationError.of(violations));
+    }
+
+    public static ErrorResponse of(ExceptionCode exceptionCode) {
+        return new ErrorResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus) {
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return new ErrorResponse(httpStatus.value(), message);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class FieldError {
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()
+                    ))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class ConstraintViolationError {
+        private String propertyPath;
+        private Object rejectedValue;
+        private String reason;
+
+        public static List<ConstraintViolationError> of(Set<ConstraintViolation<?>> constraintViolationErrors) {
+            return constraintViolationErrors.stream()
+                    .map(constraintViolation -> new ConstraintViolationError(
+                            constraintViolation.getPropertyPath().toString(),
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    ))
+                    .collect(Collectors.toList());
+        }
+    }
+}


### PR DESCRIPTION
# 🔗 Issue Number
close #1  

#📄 Description
- 요청된 메서드의 매개변수 유효성 검사에 실패한 경우(MethodArgumentNotValidException)
- Entity 객체의 유효성 검사에 실패한 경우(ConstraintViolationException)
- 지원하지 않는 HTTP 메서드를 사용하여 요청을 보내는 경우(HttpRequestMethodNotSupportedException)
- HTTP 요청 메시지를 읽을 수 없는 경우(HttpMessageNotReadableException)
- 요청 파라미터가 누락된 경우(MissingServletRequestParameterException)
- 데이터베이스에서 특정 Entity를 찾을 수 없는 경우(EntityNotFoundException)
- 사용자 정의 예외 발생 경우(EntityNotFoundException)

위에 명시된 예외가 발생한 경우,  예외 response를  반환하도록 구현하였습니다. 
